### PR TITLE
Refactor profile experience and modularize menu layout

### DIFF
--- a/lib/felulet/bejel.dart
+++ b/lib/felulet/bejel.dart
@@ -1,0 +1,344 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../services/api_service.dart';
+
+class BejelentkezesPage extends StatefulWidget {
+  const BejelentkezesPage({super.key});
+
+  @override
+  State<BejelentkezesPage> createState() => _BejelentkezesPageState();
+}
+
+class _BejelentkezesPageState extends State<BejelentkezesPage> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  bool _obscure = true;
+  bool _loading = false;
+  bool _remember = false;
+
+  static const Color green = Color(0xFF00C853);
+  static const Color dark = Color(0xFF0B1210);
+  static const Color darkCard = Color(0xFF121A18);
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _login() async {
+    FocusScope.of(context).unfocus();
+    final email = _emailController.text.trim();
+    final pass = _passwordController.text;
+    if (email.isEmpty || pass.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Te rugam sa completezi toate campurile.')),
+      );
+      return;
+    }
+
+    setState(() => _loading = true);
+    try {
+      final api = ApiService();
+      final (token, user) = await api.login(username: email, password: pass);
+      final sp = await SharedPreferences.getInstance();
+      await sp.setString('auth_token', token);
+      await sp.setString('auth_username', user['username']?.toString() ?? email);
+      if (!mounted) return;
+      setState(() => _loading = false);
+      Navigator.of(context).pushReplacementNamed('/menu');
+    } catch (e) {
+      setState(() => _loading = false);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Autentificare esuata: $e')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: dark,
+      body: SafeArea(
+        child: Stack(
+          children: [
+            // glow sus-dreapta
+            Positioned(
+              right: -120,
+              top: -100,
+              child: Container(
+                width: 320,
+                height: 320,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  gradient: RadialGradient(
+                    colors: [green.withOpacity(0.22), Colors.transparent],
+                    radius: 0.7,
+                  ),
+                ),
+              ),
+            ),
+            // glow jos-stanga
+            Positioned(
+              left: -140,
+              bottom: -120,
+              child: Container(
+                width: 300,
+                height: 300,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  gradient: RadialGradient(
+                    colors: [green.withOpacity(0.14), Colors.transparent],
+                    radius: 0.7,
+                  ),
+                ),
+              ),
+            ),
+            Center(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 480),
+                  child: Card(
+                    color: darkCard,
+                    elevation: 14,
+                    shadowColor: green.withOpacity(0.35),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(16),
+                      side: BorderSide(color: green.withOpacity(0.18), width: 1),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.all(22),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          // Header
+                          Row(
+                            children: [
+                              Container(
+                                padding: const EdgeInsets.all(10),
+                                decoration: BoxDecoration(
+                                  color: green.withOpacity(0.18),
+                                  borderRadius: BorderRadius.circular(10),
+                                ),
+                                child: Icon(
+                                  Icons.vpn_key,
+                                  color: green,
+                                  size: 26,
+                                ),
+                              ),
+                              const SizedBox(width: 14),
+                              Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: const [
+                                  Text(
+                                    'Autentificare',
+                                    style: TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 20,
+                                        fontWeight: FontWeight.w700),
+                                  ),
+                                  SizedBox(height: 4),
+                                  Text(
+                                    'Conecteaza-te la contul tau',
+                                    style: TextStyle(
+                                        color: Colors.white70, fontSize: 13),
+                                  ),
+                                ],
+                              )
+                            ],
+                          ),
+                          const SizedBox(height: 20),
+                          // Email
+                          TextField(
+                            controller: _emailController,
+                            keyboardType: TextInputType.emailAddress,
+                            style: const TextStyle(color: Colors.white),
+                            decoration: InputDecoration(
+                              filled: true,
+                              fillColor: green.withOpacity(0.12),
+                              hintText: 'Nume de utilizator',
+                              hintStyle:
+                                  const TextStyle(color: Colors.white54),
+                              prefixIcon: const Icon(Icons.person_outline,
+                                  color: Colors.white70),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: BorderSide.none,
+                              ),
+                              enabledBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: BorderSide(
+                                  color: Colors.white.withOpacity(0.10),
+                                  width: 1,
+                                ),
+                              ),
+                              focusedBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: BorderSide(
+                                  color: green,
+                                  width: 1.2,
+                                ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          // Parola
+                          TextField(
+                            controller: _passwordController,
+                            obscureText: _obscure,
+                            style: const TextStyle(color: Colors.white),
+                            decoration: InputDecoration(
+                              filled: true,
+                              fillColor: green.withOpacity(0.12),
+                              hintText: 'Parola',
+                              hintStyle:
+                                  const TextStyle(color: Colors.white54),
+                              prefixIcon: const Icon(Icons.lock_outline,
+                                  color: Colors.white70),
+                              suffixIcon: IconButton(
+                                icon: Icon(
+                                  _obscure
+                                      ? Icons.visibility_off
+                                      : Icons.visibility,
+                                  color: Colors.white70,
+                                ),
+                                onPressed: () =>
+                                    setState(() => _obscure = !_obscure),
+                              ),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: BorderSide.none,
+                              ),
+                              enabledBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: BorderSide(
+                                  color: Colors.white.withOpacity(0.10),
+                                  width: 1,
+                                ),
+                              ),
+                              focusedBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: BorderSide(
+                                  color: green,
+                                  width: 1.2,
+                                ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 10),
+                          Row(
+                            children: [
+                              GestureDetector(
+                                onTap: () => setState(() => _remember = !_remember),
+                                child: Row(
+                                  children: [
+                                    AnimatedContainer(
+                                      duration: const Duration(milliseconds: 200),
+                                      width: 18,
+                                      height: 18,
+                                      decoration: BoxDecoration(
+                                        color: _remember ? green : Colors.transparent,
+                                        borderRadius: BorderRadius.circular(4),
+                                        border: Border.all(
+                                            color: Colors.white54, width: 1.2),
+                                      ),
+                                      child: _remember
+                                          ? const Icon(Icons.check,
+                                              size: 14, color: Colors.black)
+                                          : null,
+                                    ),
+                                    const SizedBox(width: 8),
+                                    const Text('Tine-ma minte',
+                                        style: TextStyle(
+                                            color: Colors.white70, fontSize: 13)),
+                                  ],
+                                ),
+                              ),
+                              const Spacer(),
+                              TextButton(
+                                onPressed: () {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(
+                                        content: Text('Resetare parola...')),
+                                  );
+                                },
+                                child: const Text(
+                                  'Ai uitat parola?',
+                                  style: TextStyle(color: Colors.white70),
+                                ),
+                              )
+                            ],
+                          ),
+                          const SizedBox(height: 18),
+                          // Buton de conectare
+                          SizedBox(
+                            width: double.infinity,
+                            height: 50,
+                            child: ElevatedButton(
+                              onPressed: _loading ? null : _login,
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: green,
+                                shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(12)),
+                                elevation: 8,
+                                shadowColor: green.withOpacity(0.4),
+                                textStyle: const TextStyle(
+                                    fontSize: 16, fontWeight: FontWeight.w600),
+                              ),
+                              child: _loading
+                                  ? const SizedBox(
+                                      width: 22,
+                                      height: 22,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2.2,
+                                        valueColor:
+                                            AlwaysStoppedAnimation(Colors.black),
+                                      ),
+                                    )
+                                  : const Text('Conectare'),
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          // Acces alternativ
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              IconButton(
+                                onPressed: () {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(
+                                      content:
+                                          Text('Autentificare cu amprenta (exemplu)'),
+                                    ),
+                                  );
+                                },
+                                icon: const Icon(Icons.fingerprint,
+                                    color: Colors.white70),
+                                tooltip: 'Cu amprenta',
+                                splashRadius: 22,
+                                color: Colors.white,
+                              ),
+                              const SizedBox(width: 6),
+                              TextButton(
+                                onPressed: () {},
+                                child: const Text('Alt mod de autentificare',
+                                    style: TextStyle(color: Colors.white60)),
+                              )
+                            ],
+                          )
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/felulet/menu.dart
+++ b/lib/felulet/menu.dart
@@ -1,0 +1,1 @@
+export 'menu/menu_screen.dart';

--- a/lib/felulet/menu/left_side_menu.dart
+++ b/lib/felulet/menu/left_side_menu.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+
+import 'menu_item.dart';
+
+class LeftSideMenu extends StatelessWidget {
+  const LeftSideMenu({
+    super.key,
+    required this.items,
+    required this.selectedIndex,
+    required this.onItemSelected,
+    this.width = 240,
+  });
+
+  final List<MenuItemData> items;
+  final int selectedIndex;
+  final ValueChanged<int>? onItemSelected;
+  final double width;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final bg = theme.colorScheme.surface;
+    final accent = theme.colorScheme.primary;
+    final textColor = theme.textTheme.bodyMedium?.color;
+
+    return Container(
+      width: width,
+      decoration: BoxDecoration(
+        color: bg,
+        border: Border(right: BorderSide(color: theme.dividerColor.withOpacity(0.5))),
+      ),
+      child: SafeArea(
+        left: true,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
+              child: Row(
+                children: [
+                  Container(
+                    height: 44,
+                    width: 44,
+                    decoration: BoxDecoration(
+                      color: accent.withOpacity(0.12),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Icon(Icons.flutter_dash, color: accent),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      'HokiTelos',
+                      style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600, color: textColor),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: ListView.separated(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                itemCount: items.length,
+                separatorBuilder: (_, __) => const SizedBox(height: 6),
+                itemBuilder: (context, index) {
+                  final item = items[index];
+                  final selected = index == selectedIndex;
+                  return Material(
+                    color: selected ? accent.withOpacity(0.08) : Colors.transparent,
+                    child: InkWell(
+                      onTap: () {
+                        item.onTap?.call();
+                        onItemSelected?.call(index);
+                      },
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                        child: Row(
+                          children: [
+                            AnimatedContainer(
+                              duration: const Duration(milliseconds: 250),
+                              width: 4,
+                              height: 36,
+                              decoration: BoxDecoration(
+                                color: selected ? accent : Colors.transparent,
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Icon(item.icon, color: selected ? accent : theme.iconTheme.color),
+                            const SizedBox(width: 14),
+                            Expanded(
+                              child: Text(
+                                item.title,
+                                style: theme.textTheme.bodyMedium?.copyWith(
+                                  color: selected ? accent : textColor,
+                                  fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(12),
+              child: Text(
+                '2025 © HokiTelos',
+                style: theme.textTheme.bodySmall?.copyWith(color: theme.hintColor),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/felulet/menu/menu_item.dart
+++ b/lib/felulet/menu/menu_item.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+class MenuItemData {
+  const MenuItemData({required this.icon, required this.title, this.onTap});
+
+  final IconData icon;
+  final String title;
+  final VoidCallback? onTap;
+}

--- a/lib/felulet/menu/menu_screen.dart
+++ b/lib/felulet/menu/menu_screen.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+
+import '../profil/profile_page.dart';
+import 'left_side_menu.dart';
+import 'menu_item.dart';
+
+class MenuScreen extends StatefulWidget {
+  const MenuScreen({super.key});
+
+  @override
+  State<MenuScreen> createState() => _MenuScreenState();
+}
+
+class _MenuScreenState extends State<MenuScreen> {
+  int _selectedIndex = 0;
+
+  List<MenuItemData> _items() => [
+        MenuItemData(icon: Icons.home_outlined, title: 'Kezdőlap', onTap: () => _selectIndex(0)),
+        MenuItemData(icon: Icons.person_outline, title: 'Profil', onTap: () => _selectIndex(1)),
+        MenuItemData(icon: Icons.settings_outlined, title: 'Beállítások', onTap: () => _selectIndex(2)),
+        MenuItemData(icon: Icons.help_outline, title: 'Súgó', onTap: () => _selectIndex(3)),
+        MenuItemData(icon: Icons.logout, title: 'Kijelentkezés', onTap: _logout),
+      ];
+
+  void _selectIndex(int index) {
+    setState(() => _selectedIndex = index);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final titles = ['Kezdőlap', 'Profil', 'Beállítások', 'Súgó'];
+    final width = MediaQuery.of(context).size.width;
+    final isCompact = width < 720;
+
+    final content = IndexedStack(
+      index: _selectedIndex,
+      children: const [
+        _PlaceholderPage(icon: Icons.home_outlined, title: 'Üdv a főoldalon!'),
+        ProfilePage(),
+        _PlaceholderPage(icon: Icons.settings_outlined, title: 'Beállítások hamarosan'),
+        _PlaceholderPage(icon: Icons.help_outline, title: 'Segítség és GYIK készül'),
+      ],
+    );
+
+    if (isCompact) {
+      return Scaffold(
+        appBar: AppBar(title: Text(titles[_selectedIndex])),
+        drawer: Drawer(
+          child: LeftSideMenu(
+            items: _items(),
+            selectedIndex: _selectedIndex,
+            onItemSelected: (index) {
+              Navigator.pop(context);
+              _selectIndex(index);
+            },
+          ),
+        ),
+        body: content,
+      );
+    }
+
+    return Scaffold(
+      body: Row(
+        children: [
+          LeftSideMenu(
+            items: _items(),
+            selectedIndex: _selectedIndex,
+            onItemSelected: (index) => _selectIndex(index),
+          ),
+          Expanded(
+            child: Container(
+              color: Theme.of(context).colorScheme.background.withOpacity(0.02),
+              child: content,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _logout() {
+    Navigator.of(context).pushReplacementNamed('/login');
+  }
+}
+
+class _PlaceholderPage extends StatelessWidget {
+  const _PlaceholderPage({required this.icon, required this.title});
+
+  final IconData icon;
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(icon, size: 48),
+          const SizedBox(height: 12),
+          Text(title, style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 8),
+          Text('Friss és modern 2025-ös felület, hamarosan több tartalommal!'),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/felulet/profil/painters/countdown_ring_painter.dart
+++ b/lib/felulet/profil/painters/countdown_ring_painter.dart
@@ -1,0 +1,49 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+class CountdownRingPainter extends CustomPainter {
+  const CountdownRingPainter({
+    required this.progress,
+    required this.trackColor,
+    required this.glowColor,
+  });
+
+  final double progress;
+  final Color trackColor;
+  final Color glowColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = size.center(Offset.zero);
+    final radius = math.min(size.width, size.height) / 2;
+    final stroke = math.max(3.0, radius * 0.08);
+
+    final track = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = stroke
+      ..color = trackColor;
+
+    final active = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = stroke
+      ..color = glowColor.withOpacity(0.92)
+      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 8);
+
+    final rect = Rect.fromCircle(center: center, radius: radius - stroke / 2);
+    canvas.drawArc(rect, -math.pi / 2, math.pi * 2, false, track);
+
+    final sweep = (math.pi * 2) * progress.clamp(0, 1);
+    if (sweep > 0) {
+      canvas.drawArc(rect, -math.pi / 2, sweep, false, active);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CountdownRingPainter oldDelegate) {
+    return oldDelegate.progress != progress ||
+        oldDelegate.trackColor != trackColor ||
+        oldDelegate.glowColor != glowColor;
+  }
+}

--- a/lib/felulet/profil/painters/halo_painter.dart
+++ b/lib/felulet/profil/painters/halo_painter.dart
@@ -1,0 +1,45 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+class HaloPainter extends CustomPainter {
+  const HaloPainter({
+    required this.rotation,
+    required this.colors,
+    required this.strength,
+  });
+
+  final double rotation;
+  final List<Color> colors;
+  final double strength;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = size.center(Offset.zero);
+    final radius = math.min(size.width, size.height) / 2;
+    final thickness = radius * (0.1 + 0.25 * strength);
+    final blur = 4 + 12 * strength;
+    final rect = Rect.fromCircle(center: center, radius: radius - thickness / 2);
+
+    final shader = SweepGradient(
+      colors: [...colors, colors.first],
+      startAngle: rotation,
+      endAngle: rotation + math.pi * 2,
+    ).createShader(rect);
+
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = thickness
+      ..shader = shader
+      ..maskFilter = MaskFilter.blur(BlurStyle.normal, blur);
+
+    canvas.drawArc(rect, 0, math.pi * 2, false, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant HaloPainter oldDelegate) {
+    return oldDelegate.rotation != rotation ||
+        oldDelegate.strength != strength ||
+        oldDelegate.colors != colors;
+  }
+}

--- a/lib/felulet/profil/profile_page.dart
+++ b/lib/felulet/profil/profile_page.dart
@@ -1,0 +1,1332 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../services/api_service.dart';
+import '../../services/sticker_service.dart';
+import '../../utils/i18n.dart';
+import '../../utils/ui_utils.dart';
+import 'painters/countdown_ring_painter.dart';
+import 'painters/halo_painter.dart';
+import 'widgets/avatar_header.dart';
+import 'widgets/completion_card.dart';
+import 'widgets/frame_preview_strip.dart';
+import 'widgets/halo_controls_card.dart';
+import 'widgets/note_editor_page.dart';
+import 'widgets/note_overlay.dart';
+import 'widgets/profile_banner_card.dart';
+import 'widgets/profile_quick_actions.dart';
+import 'widgets/profile_save_bar.dart';
+import 'widgets/social_buttons.dart';
+
+class ProfilePage extends StatefulWidget {
+  const ProfilePage({super.key});
+
+  @override
+  State<ProfilePage> createState() => _ProfilePageState();
+}
+
+class _ProfilePageState extends State<ProfilePage> with SingleTickerProviderStateMixin {
+  final ImagePicker _picker = ImagePicker();
+
+  // Controllers
+  final TextEditingController _nameCtrl = TextEditingController();
+  final TextEditingController _descCtrl = TextEditingController();
+
+  // Avatar + banner state
+  String? _avatarPath;
+  Uint8List? _avatarBytes;
+  String? _avatarUrl;
+  String _avatarFrame = 'none';
+  String? _avatarStickerAsset;
+  String? _bannerPath;
+  Uint8List? _bannerBytes;
+  String? _bannerUrl;
+
+  // Profile metadata
+  String? _facebook;
+  String? _instagram;
+  String? _tiktok;
+  String? _youtube;
+  String? _statusNote;
+  DateTime? _statusNoteExpires;
+  String? _statusEmoji;
+  Color _noteTextColor = Colors.white;
+  Color _noteBgColor = const Color(0xDD000000);
+  double _haloStrength = 0.65;
+  bool _reduceMotion = false;
+  bool _dirty = false;
+
+  // Backend token + saving
+  String? _authToken;
+  bool _loading = true;
+  bool _saving = false;
+  Timer? _autoSaveTimer;
+  Timer? _statusTicker;
+
+  // Debounce controllers
+  Timer? _nameDebounce;
+  Timer? _descDebounce;
+
+  // Animation
+  late final AnimationController _haloCtrl;
+  String? _frameTempPreview;
+
+  // Sticker cache
+  List<Sticker> _stickers = const [];
+
+  static const List<String> _frameStyles = [
+    'none',
+    'glow-emerald',
+    'glow-azure',
+    'glow-magenta',
+    'neon-cyan',
+    'neon-amber',
+    'outline-ice',
+    'outline-coral',
+    'ring-lime',
+    'ring-violet',
+    'gradient-sunset',
+    'gradient-ocean',
+    'gradient-aurora',
+    'gradient-plasma',
+    'gradient-gold',
+    'gradient-silver',
+    'rainbow',
+  ];
+
+  static const Map<String, List<String>> _frameCategories = {
+    'All': [],
+    'Glow': ['glow-'],
+    'Neon': ['neon-'],
+    'Outline': ['outline-'],
+    'Ring': ['ring-'],
+    'Gradient': ['gradient-', 'rainbow'],
+  };
+
+  @override
+  void initState() {
+    super.initState();
+    _haloCtrl = AnimationController(vsync: this, duration: const Duration(seconds: 18))..repeat();
+    _loadProfile();
+    _nameCtrl.addListener(_onNameChanged);
+    _descCtrl.addListener(_onDescriptionChanged);
+  }
+
+  @override
+  void dispose() {
+    _nameCtrl.removeListener(_onNameChanged);
+    _descCtrl.removeListener(_onDescriptionChanged);
+    _nameCtrl.dispose();
+    _descCtrl.dispose();
+    _nameDebounce?.cancel();
+    _descDebounce?.cancel();
+    _autoSaveTimer?.cancel();
+    _statusTicker?.cancel();
+    _haloCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadProfile() async {
+    final prefs = await SharedPreferences.getInstance();
+    _authToken = prefs.getString('auth_token');
+
+    if (_authToken == null) {
+      _loadLocalSnapshot(prefs);
+      return;
+    }
+
+    try {
+      final api = ApiService();
+      final data = await api.getProfile(_authToken!);
+      if (!mounted) return;
+      setState(() {
+        _nameCtrl.text = (data['full_name'] ?? prefs.getString('profile_name') ?? '') as String;
+        _descCtrl.text = (data['description'] ?? prefs.getString('profile_description') ?? '') as String;
+        _facebook = data['social_facebook'] as String? ?? prefs.getString('profile_facebook');
+        _instagram = data['social_instagram'] as String? ?? prefs.getString('profile_instagram');
+        _tiktok = data['social_tiktok'] as String? ?? prefs.getString('profile_tiktok');
+        _youtube = data['social_youtube'] as String? ?? prefs.getString('profile_youtube');
+        _avatarUrl = data['avatar_url'] as String? ?? prefs.getString('profile_avatar_url');
+        _bannerUrl = data['banner_url'] as String? ?? prefs.getString('profile_banner_url');
+        _avatarFrame = (data['avatar_frame'] as String?) ?? prefs.getString('profile_avatar_frame') ?? 'none';
+        _avatarStickerAsset = data['avatar_sticker'] as String? ?? prefs.getString('profile_avatar_sticker_asset');
+        _statusNote = data['status_note'] as String? ?? prefs.getString('profile_status_note');
+        final se = data['status_note_expires'] as String? ?? prefs.getString('profile_status_note_expires');
+        _statusNoteExpires = se != null ? DateTime.tryParse(se) : null;
+        _statusEmoji = data['status_note_emoji'] as String? ?? prefs.getString('profile_status_note_emoji');
+        _noteTextColor = _colorFromHex(data['status_note_color'] as String?) ?? _colorFromHex(prefs.getString('profile_status_note_color')) ?? _noteTextColor;
+        _noteBgColor = _colorFromHex(data['status_note_bg'] as String?) ?? _colorFromHex(prefs.getString('profile_status_note_bg')) ?? _noteBgColor;
+        _haloStrength = double.tryParse(data['halo_strength']?.toString() ?? '') ?? prefs.getDouble('profile_halo_strength') ?? _haloStrength;
+        _reduceMotion = (data['reduce_motion'] == true) || prefs.getBool('profile_reduce_motion') == true;
+        _loading = false;
+        _dirty = false;
+      });
+      _restoreLocalImages(prefs);
+      _startStatusTicker();
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      _loadLocalSnapshot(prefs);
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Profil betöltése sikertelen: ${e.message}')));
+    } catch (e) {
+      if (!mounted) return;
+      _loadLocalSnapshot(prefs);
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Profil betöltése sikertelen: $e')));
+    }
+  }
+
+  void _loadLocalSnapshot(SharedPreferences prefs) {
+    if (!mounted) return;
+    setState(() {
+      if (kIsWeb) {
+        final b64 = prefs.getString('profile_avatar_b64');
+        _avatarBytes = (b64 != null && b64.isNotEmpty) ? base64Decode(b64) : null;
+        final bannerB64 = prefs.getString('profile_banner_b64');
+        _bannerBytes = (bannerB64 != null && bannerB64.isNotEmpty) ? base64Decode(bannerB64) : null;
+      } else {
+        _avatarPath = prefs.getString('profile_avatar');
+        _bannerPath = prefs.getString('profile_banner');
+      }
+      _avatarUrl = prefs.getString('profile_avatar_url');
+      _bannerUrl = prefs.getString('profile_banner_url');
+      _avatarFrame = prefs.getString('profile_avatar_frame') ?? 'none';
+      _avatarStickerAsset = prefs.getString('profile_avatar_sticker_asset');
+      _nameCtrl.text = prefs.getString('profile_name') ?? '';
+      _descCtrl.text = prefs.getString('profile_description') ?? '';
+      _facebook = prefs.getString('profile_facebook');
+      _instagram = prefs.getString('profile_instagram');
+      _tiktok = prefs.getString('profile_tiktok');
+      _youtube = prefs.getString('profile_youtube');
+      _statusNote = prefs.getString('profile_status_note');
+      final expires = prefs.getString('profile_status_note_expires');
+      _statusNoteExpires = expires != null ? DateTime.tryParse(expires) : null;
+      _statusEmoji = prefs.getString('profile_status_note_emoji');
+      _noteTextColor = _colorFromHex(prefs.getString('profile_status_note_color')) ?? _noteTextColor;
+      _noteBgColor = _colorFromHex(prefs.getString('profile_status_note_bg')) ?? _noteBgColor;
+      _haloStrength = prefs.getDouble('profile_halo_strength') ?? _haloStrength;
+      _reduceMotion = prefs.getBool('profile_reduce_motion') ?? _reduceMotion;
+      _loading = false;
+      _dirty = false;
+    });
+    _restoreLocalImages(prefs);
+    _startStatusTicker();
+  }
+
+  void _restoreLocalImages(SharedPreferences prefs) {
+    if (kIsWeb) {
+      final avatar = prefs.getString('profile_avatar_b64');
+      final banner = prefs.getString('profile_banner_b64');
+      setState(() {
+        _avatarBytes = (avatar != null && avatar.isNotEmpty) ? base64Decode(avatar) : _avatarBytes;
+        _bannerBytes = (banner != null && banner.isNotEmpty) ? base64Decode(banner) : _bannerBytes;
+      });
+    } else {
+      setState(() {
+        _avatarPath = prefs.getString('profile_avatar') ?? _avatarPath;
+        _bannerPath = prefs.getString('profile_banner') ?? _bannerPath;
+      });
+    }
+    if (_reduceMotion) {
+      _haloCtrl.stop();
+    } else if (!_haloCtrl.isAnimating) {
+      _haloCtrl.repeat();
+    }
+  }
+
+  void _startStatusTicker() {
+    _statusTicker?.cancel();
+    if (_statusNoteExpires == null) return;
+    _statusTicker = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (!mounted) return;
+      if (_statusNoteExpires != null && DateTime.now().isAfter(_statusNoteExpires!)) {
+        setState(() => _statusNoteExpires = null);
+        _statusTicker?.cancel();
+      } else {
+        setState(() {});
+      }
+    });
+  }
+
+  void _onNameChanged() {
+    _markDirty();
+    _nameDebounce?.cancel();
+    _nameDebounce = Timer(const Duration(milliseconds: 300), () async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('profile_name', _nameCtrl.text);
+    });
+  }
+
+  void _onDescriptionChanged() {
+    _markDirty();
+    _descDebounce?.cancel();
+    _descDebounce = Timer(const Duration(milliseconds: 400), () async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('profile_description', _descCtrl.text);
+    });
+  }
+
+  void _markDirty() {
+    if (_dirty) {
+      _scheduleAutoSave();
+      return;
+    }
+    setState(() => _dirty = true);
+    _scheduleAutoSave();
+  }
+
+  void _scheduleAutoSave() {
+    if (_authToken == null) return;
+    _autoSaveTimer?.cancel();
+    _autoSaveTimer = Timer(const Duration(seconds: 2), () {
+      if (mounted && _dirty && !_saving) {
+        _saveProfileToServer(silent: true);
+      }
+    });
+  }
+
+  Future<void> _saveProfileToServer({bool silent = false}) async {
+    final prefs = await SharedPreferences.getInstance();
+    final token = _authToken ?? prefs.getString('auth_token');
+    if (token == null) {
+      if (!silent && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(I18n.t(context, 'not_authenticated'))));
+      }
+      return;
+    }
+    if (_saving) return;
+    setState(() => _saving = true);
+
+    try {
+      final api = ApiService();
+      final payload = <String, dynamic>{
+        'full_name': _nameCtrl.text,
+        'description': _descCtrl.text,
+        'social_facebook': _facebook,
+        'social_instagram': _instagram,
+        'social_tiktok': _tiktok,
+        'social_youtube': _youtube,
+        'avatar_frame': _avatarFrame,
+        'avatar_sticker': _avatarStickerAsset,
+        if (_statusNote != null && _statusNote!.isNotEmpty) 'status_note': _statusNote,
+        if (_statusNoteExpires != null) 'status_note_expires': _statusNoteExpires!.toIso8601String(),
+        'status_note_color': _noteTextColor.value.toRadixString(16),
+        'status_note_bg': _noteBgColor.value.toRadixString(16),
+        if (_statusEmoji != null && _statusEmoji!.isNotEmpty) 'status_note_emoji': _statusEmoji,
+        'halo_strength': _haloStrength,
+        'reduce_motion': _reduceMotion,
+      };
+
+      final updated = await api.updateProfile(token, payload);
+
+      await prefs.setString('profile_name', updated['full_name']?.toString() ?? _nameCtrl.text);
+      await prefs.setString('profile_description', updated['description']?.toString() ?? _descCtrl.text);
+      _persistString(prefs, 'profile_facebook', updated['social_facebook']);
+      _persistString(prefs, 'profile_instagram', updated['social_instagram']);
+      _persistString(prefs, 'profile_tiktok', updated['social_tiktok']);
+      _persistString(prefs, 'profile_youtube', updated['social_youtube']);
+      _persistString(prefs, 'profile_avatar_url', updated['avatar_url']);
+      _persistString(prefs, 'profile_banner_url', updated['banner_url']);
+      _persistString(prefs, 'profile_avatar_frame', updated['avatar_frame'] ?? _avatarFrame);
+      _persistString(prefs, 'profile_avatar_sticker_asset', updated['avatar_sticker']);
+      _persistString(prefs, 'profile_status_note', updated['status_note']);
+      _persistString(prefs, 'profile_status_note_expires', updated['status_note_expires']);
+      _persistString(prefs, 'profile_status_note_emoji', updated['status_note_emoji']);
+      _persistString(prefs, 'profile_status_note_color', updated['status_note_color']);
+      _persistString(prefs, 'profile_status_note_bg', updated['status_note_bg']);
+      await prefs.setDouble('profile_halo_strength', _haloStrength);
+      await prefs.setBool('profile_reduce_motion', _reduceMotion);
+
+      if (!mounted) return;
+      if (!silent) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(I18n.t(context, 'profile_saved'))));
+        HapticFeedback.mediumImpact();
+      }
+      setState(() => _dirty = false);
+    } catch (e) {
+      if (!mounted) return;
+      if (!silent) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('${I18n.t(context, 'save_failed')}: $e')));
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _saving = false);
+      }
+    }
+  }
+
+  void _persistString(SharedPreferences prefs, String key, dynamic value) {
+    if (value == null || (value is String && value.isEmpty)) {
+      prefs.remove(key);
+    } else {
+      prefs.setString(key, value.toString());
+    }
+  }
+
+  Future<void> _saveAvatarFromXFile(XFile file) async {
+    final prefs = await SharedPreferences.getInstance();
+    final token = _authToken ?? prefs.getString('auth_token');
+
+    Future<void> cacheLocally({Uint8List? bytes, String? path}) async {
+      if (kIsWeb) {
+        final data = bytes ?? await file.readAsBytes();
+        await prefs.setString('profile_avatar_b64', base64Encode(data));
+        setState(() {
+          _avatarBytes = data;
+          _avatarPath = null;
+        });
+      } else {
+        final savedPath = path ?? file.path;
+        await prefs.setString('profile_avatar', savedPath);
+        setState(() {
+          _avatarPath = savedPath;
+          _avatarBytes = null;
+        });
+      }
+    }
+
+    if (token == null) {
+      await cacheLocally();
+      return;
+    }
+
+    try {
+      final api = ApiService();
+      String url;
+      if (kIsWeb) {
+        final bytes = await file.readAsBytes();
+        await cacheLocally(bytes: bytes);
+        url = await api.uploadAvatarBytes(token, bytes, filename: file.name);
+      } else {
+        await cacheLocally(path: file.path);
+        url = await api.uploadAvatarPath(token, file.path, filename: file.name);
+      }
+      await prefs.setString('profile_avatar_url', url);
+      if (!mounted) return;
+      setState(() => _avatarUrl = url);
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(I18n.t(context, 'avatar_updated'))));
+      HapticFeedback.selectionClick();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('${I18n.t(context, 'upload_error')}: $e')));
+    }
+  }
+
+  Future<void> _saveBannerFromXFile(XFile file) async {
+    final prefs = await SharedPreferences.getInstance();
+    final token = _authToken ?? prefs.getString('auth_token');
+
+    Future<void> cacheLocally({Uint8List? bytes, String? path}) async {
+      if (kIsWeb) {
+        final data = bytes ?? await file.readAsBytes();
+        await prefs.setString('profile_banner_b64', base64Encode(data));
+        setState(() {
+          _bannerBytes = data;
+          _bannerPath = null;
+        });
+      } else {
+        final savedPath = path ?? file.path;
+        await prefs.setString('profile_banner', savedPath);
+        setState(() {
+          _bannerPath = savedPath;
+          _bannerBytes = null;
+        });
+      }
+    }
+
+    if (token == null) {
+      await cacheLocally();
+      return;
+    }
+
+    try {
+      final api = ApiService();
+      String url;
+      if (kIsWeb) {
+        final bytes = await file.readAsBytes();
+        await cacheLocally(bytes: bytes);
+        url = await api.uploadBannerBytes(token, bytes, filename: file.name);
+      } else {
+        await cacheLocally(path: file.path);
+        url = await api.uploadBannerPath(token, file.path, filename: file.name);
+      }
+      await prefs.setString('profile_banner_url', url);
+      if (!mounted) return;
+      setState(() => _bannerUrl = url);
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(I18n.t(context, 'banner_updated'))));
+      HapticFeedback.selectionClick();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('${I18n.t(context, 'upload_error')}: $e')));
+    }
+  }
+
+  Future<void> _clearAvatar() async {
+    final prefs = await SharedPreferences.getInstance();
+    final token = _authToken ?? prefs.getString('auth_token');
+    if (token != null) {
+      try {
+        await ApiService().deleteAvatar(token);
+        await prefs.remove('profile_avatar_url');
+        setState(() => _avatarUrl = null);
+      } catch (e) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('${I18n.t(context, 'avatar_delete_failed')}: $e')));
+        }
+      }
+    }
+    if (kIsWeb) {
+      await prefs.remove('profile_avatar_b64');
+      setState(() => _avatarBytes = null);
+    } else {
+      await prefs.remove('profile_avatar');
+      setState(() => _avatarPath = null);
+    }
+  }
+
+  Future<void> _clearBanner() async {
+    final prefs = await SharedPreferences.getInstance();
+    final token = _authToken ?? prefs.getString('auth_token');
+    if (token != null) {
+      try {
+        await ApiService().deleteBanner(token);
+        await prefs.remove('profile_banner_url');
+        setState(() => _bannerUrl = null);
+      } catch (e) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('${I18n.t(context, 'banner_delete_failed')}: $e')));
+        }
+      }
+    }
+    if (kIsWeb) {
+      await prefs.remove('profile_banner_b64');
+      setState(() => _bannerBytes = null);
+    } else {
+      await prefs.remove('profile_banner');
+      setState(() => _bannerPath = null);
+    }
+  }
+
+  Future<void> _pickAvatar(ImageSource source) async {
+    try {
+      final file = await _picker.pickImage(source: source, maxWidth: 1200, maxHeight: 1200, imageQuality: 85);
+      if (file != null) {
+        await _saveAvatarFromXFile(file);
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('${I18n.t(context, 'image_load_error')}: $e')));
+    }
+  }
+
+  Future<void> _pickBanner(ImageSource source) async {
+    try {
+      final file = await _picker.pickImage(source: source, maxWidth: 1920, maxHeight: 1080, imageQuality: 85);
+      if (file != null) {
+        await _saveBannerFromXFile(file);
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Banner betöltése sikertelen: $e')));
+    }
+  }
+
+  void _updateFrame(String style) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('profile_avatar_frame', style);
+    setState(() => _avatarFrame = style);
+    _markDirty();
+  }
+
+  void _setTempPreview(String? style) {
+    setState(() => _frameTempPreview = style);
+  }
+
+  Future<void> _editStatusNote() async {
+    final result = await Navigator.of(context).push(NoteEditorPage.route(
+      initialText: _statusNote,
+      textColor: _noteTextColor,
+      backgroundColor: _noteBgColor,
+      emoji: _statusEmoji,
+    ));
+    if (result == null) return;
+    final prefs = await SharedPreferences.getInstance();
+    if (result.deleted) {
+      setState(() {
+        _statusNote = null;
+        _statusNoteExpires = null;
+        _statusEmoji = null;
+      });
+      await prefs.remove('profile_status_note');
+      await prefs.remove('profile_status_note_expires');
+      await prefs.remove('profile_status_note_emoji');
+      _statusTicker?.cancel();
+      _markDirty();
+      return;
+    }
+    setState(() {
+      _statusNote = result.text?.trim();
+      _noteTextColor = result.textColor;
+      _noteBgColor = result.backgroundColor;
+      _statusEmoji = result.emoji;
+      _statusNoteExpires = DateTime.now().add(const Duration(hours: 24));
+    });
+    await prefs.setString('profile_status_note', _statusNote ?? '');
+    await prefs.setString('profile_status_note_expires', _statusNoteExpires!.toIso8601String());
+    await prefs.setString('profile_status_note_color', _noteTextColor.value.toRadixString(16));
+    await prefs.setString('profile_status_note_bg', _noteBgColor.value.toRadixString(16));
+    if (_statusEmoji?.isNotEmpty == true) {
+      await prefs.setString('profile_status_note_emoji', _statusEmoji!);
+    } else {
+      await prefs.remove('profile_status_note_emoji');
+    }
+    _startStatusTicker();
+    _markDirty();
+  }
+
+  Future<void> _selectEmoji() async {
+    final emoji = await NoteEditorPage.pickEmoji(context, selected: _statusEmoji);
+    if (emoji == null) return;
+    final prefs = await SharedPreferences.getInstance();
+    setState(() => _statusEmoji = emoji.isEmpty ? null : emoji);
+    if (emoji.isEmpty) {
+      await prefs.remove('profile_status_note_emoji');
+    } else {
+      await prefs.setString('profile_status_note_emoji', emoji);
+    }
+    _markDirty();
+  }
+
+  Future<void> _saveLink(String key, String? value) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (value == null || value.isEmpty) {
+      await prefs.remove(key);
+    } else {
+      await prefs.setString(key, value);
+    }
+    setState(() {
+      switch (key) {
+        case 'profile_facebook':
+          _facebook = value;
+          break;
+        case 'profile_instagram':
+          _instagram = value;
+          break;
+        case 'profile_tiktok':
+          _tiktok = value;
+          break;
+        case 'profile_youtube':
+          _youtube = value;
+          break;
+      }
+    });
+    _markDirty();
+  }
+
+  Future<void> _editLinkDialog(String title, String prefKey, String? current) async {
+    final controller = TextEditingController(text: current ?? '');
+    await showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('${I18n.t(context, 'edit')}: $title'),
+        content: TextField(
+          controller: controller,
+          decoration: InputDecoration(hintText: I18n.t(context, 'link_hint')),
+          keyboardType: TextInputType.url,
+          textInputAction: TextInputAction.done,
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context), child: Text(I18n.t(context, 'cancel'))),
+          ElevatedButton(
+            onPressed: () {
+              final raw = controller.text.trim();
+              final normalized = UiUtils.normalizeSocial(prefKey, raw);
+              _saveLink(prefKey, normalized.isEmpty ? null : normalized);
+              Navigator.pop(context);
+              HapticFeedback.selectionClick();
+            },
+            child: Text(I18n.t(context, 'save')),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _openLink(String? url) async {
+    if (url == null || url.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(I18n.t(context, 'missing_link'))));
+      return;
+    }
+    final uri = Uri.tryParse(url);
+    if (uri == null) {
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(I18n.t(context, 'invalid_url'))));
+      return;
+    }
+    if (!await canLaunchUrl(uri)) {
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(I18n.t(context, 'cannot_launch'))));
+      return;
+    }
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  ImageProvider? _currentAvatarImage() {
+    ImageProvider? img;
+    if (_avatarUrl != null && _avatarUrl!.isNotEmpty && _avatarBytes == null && (_avatarPath == null || _avatarPath!.isEmpty)) {
+      img = NetworkImage(UiUtils.normalizeUploadUrl(_avatarUrl!));
+    }
+    if (kIsWeb) {
+      if (_avatarBytes != null && _avatarBytes!.isNotEmpty) {
+        img = MemoryImage(_avatarBytes!);
+      }
+    } else {
+      if (_avatarPath != null && _avatarPath!.isNotEmpty && File(_avatarPath!).existsSync()) {
+        img = FileImage(File(_avatarPath!));
+      }
+    }
+    return img;
+  }
+
+  ImageProvider? _currentBannerImage() {
+    ImageProvider? img;
+    if (_bannerUrl != null && _bannerUrl!.isNotEmpty && _bannerBytes == null && (_bannerPath == null || _bannerPath!.isEmpty)) {
+      img = NetworkImage(UiUtils.normalizeUploadUrl(_bannerUrl!));
+    }
+    if (kIsWeb) {
+      if (_bannerBytes != null && _bannerBytes!.isNotEmpty) {
+        img = MemoryImage(_bannerBytes!);
+      }
+    } else {
+      if (_bannerPath != null && _bannerPath!.isNotEmpty && File(_bannerPath!).existsSync()) {
+        img = FileImage(File(_bannerPath!));
+      }
+    }
+    return img;
+  }
+
+  double get _statusProgress {
+    if (_statusNoteExpires == null) return 0;
+    final end = _statusNoteExpires!;
+    final start = end.subtract(const Duration(hours: 24));
+    final now = DateTime.now();
+    final total = end.difference(start).inMilliseconds.toDouble();
+    final done = (now.isBefore(start) ? 0 : now.difference(start).inMilliseconds.toDouble()).clamp(0, total);
+    return (total == 0) ? 0 : done / total;
+  }
+
+  List<Color> _colorsForFrame(String style) {
+    switch (style) {
+      case 'glow-emerald':
+        return const [Color(0xFF00E676), Color(0xFF4CAF50)];
+      case 'glow-azure':
+        return const [Color(0xFF03A9F4), Color(0xFF00BCD4)];
+      case 'glow-magenta':
+        return const [Color(0xFFFF4081), Color(0xFFE040FB)];
+      case 'neon-cyan':
+        return const [Color(0xFF00E5FF), Color(0xFF18FFFF)];
+      case 'neon-amber':
+        return const [Color(0xFFFFEA00), Color(0xFFFFC400)];
+      case 'outline-ice':
+        return const [Color(0xFF90CAF9), Color(0xFFE3F2FD)];
+      case 'outline-coral':
+        return const [Color(0xFFFFAB91), Color(0xFFFF7043)];
+      case 'ring-lime':
+        return const [Color(0xFF76FF03), Color(0xFFB2FF59)];
+      case 'ring-violet':
+        return const [Color(0xFF7C4DFF), Color(0xFFB388FF)];
+      case 'gradient-sunset':
+        return const [Color(0xFFFF512F), Color(0xFFF09819)];
+      case 'gradient-ocean':
+        return const [Color(0xFF36D1DC), Color(0xFF5B86E5)];
+      case 'gradient-aurora':
+        return const [Color(0xFF00C9FF), Color(0xFF92FE9D)];
+      case 'gradient-plasma':
+        return const [Color(0xFF12C2E9), Color(0xFFC471ED), Color(0xFFF64F59)];
+      case 'gradient-gold':
+        return const [Color(0xFFFFD700), Color(0xFFFFB700)];
+      case 'gradient-silver':
+        return const [Color(0xFFBCC6CC), Color(0xFFE5E4E2)];
+      case 'rainbow':
+        return const [Colors.red, Colors.orange, Colors.yellow, Colors.green, Colors.blue, Colors.indigo, Colors.purple];
+      default:
+        final color = Theme.of(context).colorScheme.primary;
+        return [color, color.withOpacity(0.5)];
+    }
+  }
+
+  Future<void> _revertLocal() async {
+    final prefs = await SharedPreferences.getInstance();
+    _loadLocalSnapshot(prefs);
+    setState(() => _dirty = false);
+  }
+
+  Color? _colorFromHex(String? hex) {
+    if (hex == null || hex.isEmpty) return null;
+    final value = hex.replaceAll('#', '');
+    if (value.length != 6 && value.length != 8) return null;
+    try {
+      final parsed = int.parse(value, radix: 16);
+      if (value.length == 6) {
+        return Color(int.parse('FF$value', radix: 16));
+      }
+      return Color(parsed);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  double _completeness() {
+    int have = 0;
+    const total = 4;
+    if (_nameCtrl.text.trim().isNotEmpty) have++;
+    if (_descCtrl.text.trim().isNotEmpty) have++;
+    if (_currentAvatarImage() != null || (_avatarUrl ?? '').isNotEmpty) have++;
+    if ((_facebook ?? '').isNotEmpty || (_instagram ?? '').isNotEmpty || (_tiktok ?? '').isNotEmpty || (_youtube ?? '').isNotEmpty) have++;
+    return have / total;
+  }
+
+  Future<bool> _onBackPressed() async {
+    if (!_dirty) return true;
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(I18n.t(context, 'unsaved_changes')),
+        content: Text(I18n.t(context, 'leave_without_save')),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context, false), child: Text(I18n.t(context, 'stay'))),
+          TextButton(onPressed: () => Navigator.pop(context, true), child: Text(I18n.t(context, 'leave'))),
+        ],
+      ),
+    );
+    return result ?? false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    final media = MediaQuery.of(context);
+    final textScale = media.textScaleFactor.clamp(0.9, 1.2);
+
+    return WillPopScope(
+      onWillPop: _onBackPressed,
+      child: MediaQuery(
+        data: media.copyWith(textScaler: TextScaler.linear(textScale)),
+        child: Scaffold(
+          appBar: AppBar(
+            title: Text(I18n.t(context, 'profile')),
+          ),
+          body: RefreshIndicator(
+            onRefresh: _loadProfile,
+            child: SingleChildScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                children: [
+                  ProfileBannerCard(
+                    image: _currentBannerImage(),
+                    onPick: _pickBanner,
+                    onDelete: _clearBanner,
+                  ),
+                  const SizedBox(height: 12),
+                  AvatarHeader(
+                    haloAnimation: _haloCtrl,
+                    haloStrength: _haloStrength,
+                    reduceMotion: _reduceMotion,
+                    frameStyle: _frameTempPreview ?? _avatarFrame,
+                    colorsForFrame: _colorsForFrame,
+                    avatarRadius: media.size.width < 420 ? 48 : 64,
+                    avatarImage: _currentAvatarImage(),
+                    displayName: _nameCtrl.text.trim(),
+                    statusNote: (_statusNoteExpires == null || DateTime.now().isBefore(_statusNoteExpires!)) ? _statusNote : null,
+                    statusProgress: _statusProgress,
+                    noteTextColor: _noteTextColor,
+                    noteBgColor: _noteBgColor,
+                    statusEmoji: _statusEmoji,
+                    onAvatarTap: () => _showAvatarOptions(),
+                    onEditStatus: _editStatusNote,
+                    onPickEmoji: _selectEmoji,
+                    onFrameSwipe: _cycleFrame,
+                    onRandomizeFrame: _randomizeFrame,
+                    stickerAsset: _avatarStickerAsset,
+                  ),
+                  const SizedBox(height: 16),
+                  ProfileQuickActions(
+                    onFramePicker: _openFramePicker,
+                    onRandomize: _randomizeFrame,
+                    onEditStatus: _editStatusNote,
+                  ),
+                  const SizedBox(height: 16),
+                  CompletionCard(percent: _completeness()),
+                  const SizedBox(height: 16),
+                  _decoratedField(
+                    child: TextField(
+                      controller: _nameCtrl,
+                      textInputAction: TextInputAction.next,
+                      decoration: InputDecoration(
+                        labelText: I18n.t(context, 'name'),
+                        prefixIcon: const Icon(Icons.person_outline),
+                        border: OutlineInputBorder(borderRadius: BorderRadius.circular(14)),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  _decoratedField(
+                    child: TextField(
+                      controller: _descCtrl,
+                      maxLines: 4,
+                      decoration: InputDecoration(
+                        labelText: I18n.t(context, 'description'),
+                        alignLabelWithHint: true,
+                        border: OutlineInputBorder(borderRadius: BorderRadius.circular(14)),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(I18n.t(context, 'avatar_frame'), style: Theme.of(context).textTheme.titleMedium),
+                  ),
+                  const SizedBox(height: 10),
+                  FramePreviewStrip(
+                    styles: _frameStyles,
+                    selected: _avatarFrame,
+                    image: _currentAvatarImage(),
+                    name: _nameCtrl.text.trim(),
+                    onSelected: _updateFrame,
+                    colorsFor: _colorsForFrame,
+                  ),
+                  const SizedBox(height: 20),
+                  HaloControlsCard(
+                    haloStrength: _haloStrength,
+                    reduceMotion: _reduceMotion,
+                    onHaloChanged: (value) async {
+                      final prefs = await SharedPreferences.getInstance();
+                      await prefs.setDouble('profile_halo_strength', value);
+                      setState(() => _haloStrength = value);
+                      _markDirty();
+                    },
+                    onReduceMotionChanged: (value) async {
+                      final prefs = await SharedPreferences.getInstance();
+                      await prefs.setBool('profile_reduce_motion', value);
+                      setState(() => _reduceMotion = value);
+                      if (value) {
+                        _haloCtrl.stop();
+                      } else if (!_haloCtrl.isAnimating) {
+                        _haloCtrl.repeat();
+                      }
+                      _markDirty();
+                    },
+                  ),
+                  const SizedBox(height: 20),
+                  _buildStickerPicker(),
+                  const SizedBox(height: 24),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(I18n.t(context, 'social_media'), style: Theme.of(context).textTheme.titleMedium),
+                  ),
+                  const SizedBox(height: 10),
+                  SocialButtonsRow(
+                    facebook: _facebook,
+                    instagram: _instagram,
+                    tiktok: _tiktok,
+                    youtube: _youtube,
+                    onEdit: _editLinkDialog,
+                    onOpen: _openLink,
+                  ),
+                  const SizedBox(height: 80),
+                ],
+              ),
+            ),
+          ),
+          bottomNavigationBar: ProfileSaveBar(
+            visible: _dirty && _authToken != null,
+            saving: _saving,
+            onDiscard: _revertLocal,
+            onSave: () => _saveProfileToServer(silent: false),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _decoratedField({required Widget child}) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(0.04),
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: Colors.white.withOpacity(0.06)),
+        boxShadow: [
+          BoxShadow(color: Colors.black.withOpacity(0.2), blurRadius: 20, offset: const Offset(0, 12)),
+        ],
+      ),
+      padding: const EdgeInsets.all(12),
+      child: child,
+    );
+  }
+
+  Widget _buildStickerPicker() {
+    return FutureBuilder<List<Sticker>>(
+      future: StickerService().loadStickers(),
+      builder: (context, snapshot) {
+        _stickers = snapshot.data ?? _stickers;
+        final stickers = _stickers;
+        if (stickers.isEmpty) {
+          return _decoratedField(
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Text(I18n.t(context, 'no_stickers')),
+            ),
+          );
+        }
+        return _decoratedField(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  const Icon(Icons.emoji_emotions_outlined, size: 18),
+                  const SizedBox(width: 8),
+                  Text(I18n.t(context, 'sticker')),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Wrap(
+                spacing: 12,
+                runSpacing: 12,
+                children: [
+                  for (final sticker in stickers)
+                    GestureDetector(
+                      onTap: () async {
+                        final prefs = await SharedPreferences.getInstance();
+                        final value = sticker.asset ?? sticker.url;
+                        if (value == null) return;
+                        await prefs.setString('profile_avatar_sticker_asset', value);
+                        setState(() => _avatarStickerAsset = value);
+                        _markDirty();
+                      },
+                      child: AnimatedContainer(
+                        duration: const Duration(milliseconds: 200),
+                        padding: const EdgeInsets.all(10),
+                        decoration: BoxDecoration(
+                          color: Colors.white.withOpacity(0.06),
+                          borderRadius: BorderRadius.circular(16),
+                          border: Border.all(
+                            color: (_avatarStickerAsset == (sticker.asset ?? sticker.url))
+                                ? Theme.of(context).colorScheme.primary
+                                : Colors.white24,
+                            width: 1.6,
+                          ),
+                        ),
+                        child: SizedBox(
+                          width: 64,
+                          height: 64,
+                          child: sticker.asset != null
+                              ? Image.asset('assets/stickers/${sticker.asset!}', fit: BoxFit.contain)
+                              : Image.network(sticker.url!, fit: BoxFit.contain),
+                        ),
+                      ),
+                    ),
+                  GestureDetector(
+                    onTap: () async {
+                      final prefs = await SharedPreferences.getInstance();
+                      await prefs.remove('profile_avatar_sticker_asset');
+                      setState(() => _avatarStickerAsset = null);
+                      _markDirty();
+                    },
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                      decoration: BoxDecoration(
+                        color: Colors.white.withOpacity(0.08),
+                        borderRadius: BorderRadius.circular(16),
+                        border: Border.all(color: Colors.white24),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Icon(Icons.close, size: 18),
+                          const SizedBox(width: 6),
+                          Text(I18n.t(context, 'remove')),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  void _cycleFrame(int direction) {
+    final index = _frameStyles.indexOf(_avatarFrame);
+    if (index == -1) {
+      _updateFrame(_frameStyles.first);
+      return;
+    }
+    final next = (index + direction) % _frameStyles.length;
+    final style = _frameStyles[(next + _frameStyles.length) % _frameStyles.length];
+    _updateFrame(style);
+  }
+
+  void _randomizeFrame() {
+    final frames = _frameStyles.where((element) => element != 'none').toList();
+    frames.shuffle();
+    if (frames.isNotEmpty) {
+      _updateFrame(frames.first);
+    }
+  }
+
+  Future<void> _openFramePicker() async {
+    final selected = await showModalBottomSheet<String>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => FramePreviewSheet(
+        categories: _frameCategories,
+        current: _avatarFrame,
+        styles: _frameStyles,
+        colorsFor: _colorsForFrame,
+        onPreviewStart: _setTempPreview,
+        onPreviewEnd: () => _setTempPreview(null),
+      ),
+    );
+    if (selected != null) {
+      _updateFrame(selected);
+    }
+  }
+
+  Future<void> _showAvatarOptions() async {
+    await showModalBottomSheet<void>(
+      context: context,
+      builder: (context) => SafeArea(
+        child: Wrap(
+          children: [
+            ListTile(
+              leading: const Icon(Icons.photo_library),
+              title: Text(I18n.t(context, 'pick_from_gallery')),
+              onTap: () {
+                Navigator.pop(context);
+                _pickAvatar(ImageSource.gallery);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.camera_alt),
+              title: Text(I18n.t(context, 'take_photo')),
+              onTap: () {
+                Navigator.pop(context);
+                _pickAvatar(ImageSource.camera);
+              },
+            ),
+            if ((_avatarUrl ?? '').isNotEmpty || (_avatarBytes != null && _avatarBytes!.isNotEmpty) || (_avatarPath ?? '').isNotEmpty)
+              ListTile(
+                leading: const Icon(Icons.delete_outline),
+                title: Text(I18n.t(context, 'delete_avatar')),
+                onTap: () {
+                  Navigator.pop(context);
+                  _clearAvatar();
+                },
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class FramePreviewSheet extends StatefulWidget {
+  const FramePreviewSheet({
+    super.key,
+    required this.styles,
+    required this.current,
+    required this.categories,
+    required this.colorsFor,
+    this.onPreviewStart,
+    this.onPreviewEnd,
+  });
+
+  final List<String> styles;
+  final String current;
+  final Map<String, List<String>> categories;
+  final List<Color> Function(String) colorsFor;
+  final ValueChanged<String>? onPreviewStart;
+  final VoidCallback? onPreviewEnd;
+
+  @override
+  State<FramePreviewSheet> createState() => _FramePreviewSheetState();
+}
+
+class _FramePreviewSheetState extends State<FramePreviewSheet> {
+  String _category = 'All';
+  String _query = '';
+
+  List<String> get _filtered {
+    Iterable<String> source = widget.styles;
+    final prefixes = widget.categories[_category] ?? [];
+    if (prefixes.isNotEmpty) {
+      source = source.where((element) => prefixes.any((prefix) => element.startsWith(prefix)) || (prefixes.contains('rainbow') && element == 'rainbow'));
+    }
+    if (_query.isNotEmpty) {
+      source = source.where((element) => element.toLowerCase().contains(_query.toLowerCase()));
+    }
+    return source.toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return DraggableScrollableSheet(
+      initialChildSize: 0.75,
+      minChildSize: 0.45,
+      maxChildSize: 0.95,
+      builder: (context, controller) => Container(
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surface,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+          boxShadow: [
+            BoxShadow(color: Colors.black.withOpacity(0.35), blurRadius: 30, offset: const Offset(0, -4)),
+          ],
+        ),
+        child: Column(
+          children: [
+            const SizedBox(height: 12),
+            Container(width: 46, height: 5, decoration: BoxDecoration(color: Colors.white24, borderRadius: BorderRadius.circular(4))),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 0),
+              child: Row(
+                children: [
+                  const Icon(Icons.brush_outlined),
+                  const SizedBox(width: 8),
+                  Text(I18n.t(context, 'frame_picker'), style: theme.textTheme.titleMedium),
+                  const Spacer(),
+                  IconButton(onPressed: () => Navigator.pop(context), icon: const Icon(Icons.close)),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+              child: TextField(
+                onChanged: (value) => setState(() => _query = value),
+                decoration: InputDecoration(
+                  prefixIcon: const Icon(Icons.search),
+                  hintText: I18n.t(context, 'search_frames'),
+                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                  isDense: true,
+                ),
+              ),
+            ),
+            SizedBox(
+              height: 44,
+              child: ListView.separated(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                scrollDirection: Axis.horizontal,
+                itemBuilder: (context, index) {
+                  final name = widget.categories.keys.elementAt(index);
+                  return ChoiceChip(
+                    label: Text(name),
+                    selected: name == _category,
+                    onSelected: (_) => setState(() => _category = name),
+                  );
+                },
+                separatorBuilder: (_, __) => const SizedBox(width: 8),
+                itemCount: widget.categories.length,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Expanded(
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final crossAxisCount = () {
+                    final width = constraints.maxWidth;
+                    if (width < 360) return 3;
+                    if (width < 520) return 4;
+                    if (width < 760) return 5;
+                    return 6;
+                  }();
+                  return GridView.builder(
+                    controller: controller,
+                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: crossAxisCount,
+                      crossAxisSpacing: 12,
+                      mainAxisSpacing: 12,
+                      childAspectRatio: 0.85,
+                    ),
+                    itemCount: _filtered.length,
+                    itemBuilder: (context, index) {
+                      final style = _filtered[index];
+                      final selected = widget.current == style;
+                      return GestureDetector(
+                        onTap: () => Navigator.pop(context, style),
+                        onLongPressStart: (_) => widget.onPreviewStart?.call(style),
+                        onLongPressEnd: (_) => widget.onPreviewEnd?.call(),
+                        child: AnimatedContainer(
+                          duration: const Duration(milliseconds: 220),
+                          padding: const EdgeInsets.all(10),
+                          decoration: BoxDecoration(
+                            color: Colors.white.withOpacity(0.05),
+                            borderRadius: BorderRadius.circular(18),
+                            border: Border.all(
+                              color: selected ? theme.colorScheme.primary : Colors.white.withOpacity(0.08),
+                              width: selected ? 2 : 1,
+                            ),
+                          ),
+                          child: Column(
+                            children: [
+                              Expanded(
+                                child: CustomPaint(
+                                  painter: _FrameSwatchPainter(colors: widget.colorsFor(style)),
+                                ),
+                              ),
+                              const SizedBox(height: 8),
+                              Text(style, maxLines: 1, overflow: TextOverflow.ellipsis, style: const TextStyle(fontSize: 11)),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FrameSwatchPainter extends CustomPainter {
+  const _FrameSwatchPainter({required this.colors});
+  final List<Color> colors;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = size.center(Offset.zero);
+    final radius = math.min(size.width, size.height) / 2 - 6;
+    final stroke = math.max(6.0, radius * 0.28);
+    final rect = Rect.fromCircle(center: center, radius: radius);
+    final shader = SweepGradient(colors: [...colors, colors.first]).createShader(rect);
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = stroke
+      ..shader = shader
+      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 6);
+    canvas.drawArc(rect, 0, math.pi * 2, false, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _FrameSwatchPainter oldDelegate) => oldDelegate.colors != colors;
+}

--- a/lib/felulet/profil/widgets/avatar_header.dart
+++ b/lib/felulet/profil/widgets/avatar_header.dart
@@ -1,0 +1,175 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../painters/countdown_ring_painter.dart';
+import '../painters/halo_painter.dart';
+import 'framed_avatar.dart';
+import 'note_overlay.dart';
+
+class AvatarHeader extends StatelessWidget {
+  const AvatarHeader({
+    super.key,
+    required this.haloAnimation,
+    required this.haloStrength,
+    required this.reduceMotion,
+    required this.frameStyle,
+    required this.colorsForFrame,
+    required this.avatarRadius,
+    required this.avatarImage,
+    required this.displayName,
+    required this.statusNote,
+    required this.statusProgress,
+    required this.noteTextColor,
+    required this.noteBgColor,
+    required this.statusEmoji,
+    required this.onAvatarTap,
+    required this.onEditStatus,
+    required this.onPickEmoji,
+    required this.onFrameSwipe,
+    required this.onRandomizeFrame,
+    this.stickerAsset,
+  });
+
+  final Animation<double> haloAnimation;
+  final double haloStrength;
+  final bool reduceMotion;
+  final String frameStyle;
+  final List<Color> Function(String) colorsForFrame;
+  final double avatarRadius;
+  final ImageProvider? avatarImage;
+  final String displayName;
+  final String? statusNote;
+  final double statusProgress;
+  final Color noteTextColor;
+  final Color noteBgColor;
+  final String? statusEmoji;
+  final VoidCallback onAvatarTap;
+  final VoidCallback onEditStatus;
+  final VoidCallback onPickEmoji;
+  final ValueChanged<int> onFrameSwipe;
+  final VoidCallback onRandomizeFrame;
+  final String? stickerAsset;
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    final isSmall = width < 420;
+    final bubbleSpace = isSmall ? 44.0 : 56.0;
+    final tileWidth = avatarRadius * 2 + (isSmall ? 160 : 220);
+    final haloSize = avatarRadius * 2 + 16;
+    final stickerImage = _resolveSticker();
+
+    return SizedBox(
+      height: bubbleSpace + avatarRadius * 2 + 32,
+      child: Center(
+        child: SizedBox(
+          width: tileWidth,
+          height: bubbleSpace + avatarRadius * 2,
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: [
+              Positioned(
+                top: bubbleSpace - 10,
+                left: (tileWidth - haloSize) / 2,
+                child: AnimatedBuilder(
+                  animation: haloAnimation,
+                  builder: (context, _) {
+                    return CustomPaint(
+                      size: Size.square(haloSize),
+                      painter: HaloPainter(
+                        rotation: reduceMotion ? 0 : haloAnimation.value * math.pi * 2,
+                        colors: colorsForFrame(frameStyle),
+                        strength: haloStrength,
+                      ),
+                    );
+                  },
+                ),
+              ),
+              Positioned(
+                top: bubbleSpace,
+                left: (tileWidth - avatarRadius * 2) / 2,
+                child: GestureDetector(
+                  onTap: () {
+                    HapticFeedback.selectionClick();
+                    onAvatarTap();
+                  },
+                  onDoubleTap: () {
+                    HapticFeedback.mediumImpact();
+                    onRandomizeFrame();
+                  },
+                  onHorizontalDragEnd: (details) {
+                    final velocity = details.primaryVelocity ?? 0;
+                    if (velocity.abs() > 60) {
+                      onFrameSwipe(velocity < 0 ? 1 : -1);
+                    }
+                  },
+                  child: Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      FramedAvatar(
+                        radius: avatarRadius,
+                        image: avatarImage,
+                        name: displayName,
+                        frameStyle: frameStyle,
+                        stickerImage: stickerImage,
+                      ),
+                      if (statusNote != null && statusNote!.isNotEmpty)
+                        Positioned.fill(
+                          child: IgnorePointer(
+                            child: CustomPaint(
+                              painter: CountdownRingPainter(
+                                progress: statusProgress,
+                                trackColor: Colors.white.withOpacity(0.14),
+                                glowColor: Theme.of(context).colorScheme.primary,
+                              ),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+              Positioned(
+                top: bubbleSpace + avatarRadius * 2 - 38,
+                left: (tileWidth + avatarRadius * 2) / 2 - 38,
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.primary,
+                    shape: BoxShape.circle,
+                    border: Border.all(color: Colors.white, width: 2),
+                  ),
+                  padding: const EdgeInsets.all(6),
+                  child: const Icon(Icons.camera_alt, color: Colors.white, size: 20),
+                ),
+              ),
+              if (statusNote != null && statusNote!.isNotEmpty)
+                Positioned(
+                  top: 6,
+                  right: math.max(16, tileWidth * 0.18),
+                  child: NoteOverlay(
+                    text: statusNote!,
+                    textColor: noteTextColor,
+                    bgColor: noteBgColor,
+                    emoji: statusEmoji,
+                    onEdit: onEditStatus,
+                    onPickEmoji: onPickEmoji,
+                    maxWidth: isSmall ? 200 : 260,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  ImageProvider? _resolveSticker() {
+    if (stickerAsset == null || stickerAsset!.isEmpty) return null;
+    if (stickerAsset!.startsWith('http')) {
+      return NetworkImage(stickerAsset!);
+    }
+    return AssetImage('assets/stickers/$stickerAsset');
+  }
+}

--- a/lib/felulet/profil/widgets/completion_card.dart
+++ b/lib/felulet/profil/widgets/completion_card.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class CompletionCard extends StatelessWidget {
+  const CompletionCard({super.key, required this.percent});
+
+  final double percent;
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = percent.clamp(0, 1);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(0.04),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: Colors.white.withOpacity(0.06)),
+        boxShadow: [BoxShadow(color: Colors.black.withOpacity(0.22), blurRadius: 24, offset: const Offset(0, 12))],
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.check_circle_outline, size: 22),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text('Profil készültség: ${(progress * 100).round()}%'),
+          ),
+          const SizedBox(width: 12),
+          SizedBox(
+            width: 140,
+            height: 8,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: LinearProgressIndicator(
+                value: progress,
+                backgroundColor: Colors.white.withOpacity(0.1),
+                color: Theme.of(context).colorScheme.primary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/felulet/profil/widgets/frame_preview_strip.dart
+++ b/lib/felulet/profil/widgets/frame_preview_strip.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+
+class FramePreviewStrip extends StatelessWidget {
+  const FramePreviewStrip({
+    super.key,
+    required this.styles,
+    required this.selected,
+    required this.image,
+    required this.name,
+    required this.onSelected,
+    required this.colorsFor,
+  });
+
+  final List<String> styles;
+  final String selected;
+  final ImageProvider? image;
+  final String name;
+  final ValueChanged<String> onSelected;
+  final List<Color> Function(String) colorsFor;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 120,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        itemCount: styles.length,
+        separatorBuilder: (_, __) => const SizedBox(width: 12),
+        itemBuilder: (context, index) {
+          final style = styles[index];
+          final isSelected = style == selected;
+          return GestureDetector(
+            onTap: () => onSelected(style),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 220),
+              width: 96,
+              decoration: BoxDecoration(
+                color: Colors.white.withOpacity(0.04),
+                borderRadius: BorderRadius.circular(18),
+                border: Border.all(
+                  color: isSelected ? Theme.of(context).colorScheme.primary : Colors.white.withOpacity(0.08),
+                  width: isSelected ? 2 : 1,
+                ),
+              ),
+              padding: const EdgeInsets.all(10),
+              child: Column(
+                children: [
+                  CircleAvatar(
+                    radius: 28,
+                    backgroundImage: image,
+                    backgroundColor: Colors.black12,
+                    child: image == null
+                        ? Text(
+                            _initials(name),
+                            style: const TextStyle(fontWeight: FontWeight.bold),
+                          )
+                        : null,
+                  ),
+                  const SizedBox(height: 8),
+                  Container(
+                    height: 8,
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(colors: colorsFor(style)),
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    style,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(fontSize: 11),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  String _initials(String name) {
+    final text = name
+        .split(' ')
+        .where((element) => element.isNotEmpty)
+        .take(2)
+        .map((e) => e[0])
+        .join()
+        .toUpperCase();
+    return text.isEmpty ? '?' : text;
+  }
+}

--- a/lib/felulet/profil/widgets/framed_avatar.dart
+++ b/lib/felulet/profil/widgets/framed_avatar.dart
@@ -1,0 +1,117 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+class FramedAvatar extends StatelessWidget {
+  const FramedAvatar({
+    super.key,
+    required this.radius,
+    this.image,
+    this.name,
+    required this.frameStyle,
+    this.stickerImage,
+  });
+
+  final double radius;
+  final ImageProvider? image;
+  final String? name;
+  final String frameStyle;
+  final ImageProvider? stickerImage;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = _colorsForStyle(context, frameStyle);
+    final hasSticker = stickerImage != null;
+
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        Container(
+          width: radius * 2,
+          height: radius * 2,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            gradient: LinearGradient(
+              colors: colors,
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+          ),
+          padding: const EdgeInsets.all(4),
+          child: CircleAvatar(
+            backgroundImage: image,
+            backgroundColor: Colors.black12,
+            child: image == null ? _initials(name) : null,
+          ),
+        ),
+        if (hasSticker)
+          Positioned(
+            right: -6,
+            bottom: -6,
+            child: Container(
+              width: math.max(48, radius * 0.9),
+              height: math.max(48, radius * 0.9),
+              decoration: BoxDecoration(
+                color: Colors.black.withOpacity(0.2),
+                shape: BoxShape.circle,
+                border: Border.all(color: Colors.white, width: 2),
+              ),
+              padding: const EdgeInsets.all(6),
+              child: Image(image: stickerImage!, fit: BoxFit.contain),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _initials(String? name) {
+    final text = (name ?? '')
+        .split(' ')
+        .where((element) => element.isNotEmpty)
+        .take(2)
+        .map((e) => e[0])
+        .join()
+        .toUpperCase();
+    return Text(text.isEmpty ? '?' : text, style: const TextStyle(fontSize: 28, fontWeight: FontWeight.w600));
+  }
+
+  List<Color> _colorsForStyle(BuildContext context, String style) {
+    switch (style) {
+      case 'glow-emerald':
+        return const [Color(0xFF00E676), Color(0xFF2ECC71)];
+      case 'glow-azure':
+        return const [Color(0xFF03A9F4), Color(0xFF40C4FF)];
+      case 'glow-magenta':
+        return const [Color(0xFFFF4081), Color(0xFFE040FB)];
+      case 'neon-cyan':
+        return const [Color(0xFF00E5FF), Color(0xFF18FFFF)];
+      case 'neon-amber':
+        return const [Color(0xFFFFD740), Color(0xFFFFAB00)];
+      case 'outline-ice':
+        return const [Color(0xFF90CAF9), Color(0xFFE3F2FD)];
+      case 'outline-coral':
+        return const [Color(0xFFFFAB91), Color(0xFFFF7043)];
+      case 'ring-lime':
+        return const [Color(0xFFB9F6CA), Color(0xFF76FF03)];
+      case 'ring-violet':
+        return const [Color(0xFFB388FF), Color(0xFF7C4DFF)];
+      case 'gradient-sunset':
+        return const [Color(0xFFFF512F), Color(0xFFF09819)];
+      case 'gradient-ocean':
+        return const [Color(0xFF36D1DC), Color(0xFF5B86E5)];
+      case 'gradient-aurora':
+        return const [Color(0xFF00C9FF), Color(0xFF92FE9D)];
+      case 'gradient-plasma':
+        return const [Color(0xFF12C2E9), Color(0xFFC471ED), Color(0xFFF64F59)];
+      case 'gradient-gold':
+        return const [Color(0xFFFFD700), Color(0xFFFFB300)];
+      case 'gradient-silver':
+        return const [Color(0xFFBEC2C6), Color(0xFFE5E4E2)];
+      case 'rainbow':
+        return const [Colors.red, Colors.orange, Colors.yellow, Colors.green, Colors.blue, Colors.purple];
+      default:
+        final color = Theme.of(context).colorScheme.primary;
+        return [color.withOpacity(0.8), color.withOpacity(0.4)];
+    }
+  }
+}

--- a/lib/felulet/profil/widgets/halo_controls_card.dart
+++ b/lib/felulet/profil/widgets/halo_controls_card.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+class HaloControlsCard extends StatelessWidget {
+  const HaloControlsCard({
+    super.key,
+    required this.haloStrength,
+    required this.reduceMotion,
+    required this.onHaloChanged,
+    required this.onReduceMotionChanged,
+  });
+
+  final double haloStrength;
+  final bool reduceMotion;
+  final ValueChanged<double> onHaloChanged;
+  final ValueChanged<bool> onReduceMotionChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(0.04),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: Colors.white.withOpacity(0.06)),
+        boxShadow: [BoxShadow(color: Colors.black.withOpacity(0.2), blurRadius: 24, offset: const Offset(0, 12))],
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.auto_fix_high_outlined, size: 20),
+              const SizedBox(width: 10),
+              Text('Halo beállítás', style: Theme.of(context).textTheme.titleMedium),
+              const Spacer(),
+              Text('${(haloStrength * 100).round()}%'),
+            ],
+          ),
+          Slider(
+            value: haloStrength,
+            onChanged: onHaloChanged,
+          ),
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            title: const Text('Mozgás csökkentése'),
+            subtitle: const Text('Állítsd le az animációkat energiatakarékossághoz.'),
+            value: reduceMotion,
+            onChanged: onReduceMotionChanged,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/felulet/profil/widgets/note_editor_page.dart
+++ b/lib/felulet/profil/widgets/note_editor_page.dart
@@ -1,0 +1,293 @@
+import 'package:flutter/material.dart';
+
+class NoteEditorResult {
+  const NoteEditorResult({
+    required this.text,
+    required this.textColor,
+    required this.backgroundColor,
+    required this.emoji,
+    this.deleted = false,
+  });
+
+  final String? text;
+  final Color textColor;
+  final Color backgroundColor;
+  final String? emoji;
+  final bool deleted;
+}
+
+class NoteEditorPage extends StatefulWidget {
+  const NoteEditorPage({
+    super.key,
+    this.initialText,
+    required this.textColor,
+    required this.backgroundColor,
+    this.emoji,
+  });
+
+  final String? initialText;
+  final Color textColor;
+  final Color backgroundColor;
+  final String? emoji;
+
+  static Route<NoteEditorResult?> route({
+    String? initialText,
+    required Color textColor,
+    required Color backgroundColor,
+    String? emoji,
+  }) {
+    return MaterialPageRoute<NoteEditorResult?>(
+      fullscreenDialog: true,
+      builder: (_) => NoteEditorPage(
+        initialText: initialText,
+        textColor: textColor,
+        backgroundColor: backgroundColor,
+        emoji: emoji,
+      ),
+    );
+  }
+
+  static Future<String?> pickEmoji(BuildContext context, {String? selected}) async {
+    const options = ['😀', '😎', '🔥', '🌈', '💡', '💜', '🚀', '💬', ''];
+    return showModalBottomSheet<String?>(
+      context: context,
+      builder: (context) => SafeArea(
+        child: Wrap(
+          children: [
+            for (final emoji in options)
+              ListTile(
+                leading: Text(emoji.isEmpty ? '🚫' : emoji, style: const TextStyle(fontSize: 22)),
+                title: Text(emoji.isEmpty ? 'Eltávolítás' : 'Válaszd: $emoji'),
+                trailing: emoji == selected ? const Icon(Icons.check) : null,
+                onTap: () => Navigator.pop(context, emoji),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  State<NoteEditorPage> createState() => _NoteEditorPageState();
+}
+
+class _NoteEditorPageState extends State<NoteEditorPage> {
+  late TextEditingController _controller;
+  late Color _textColor;
+  late Color _backgroundColor;
+  String? _emoji;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialText ?? '');
+    _textColor = widget.textColor;
+    _backgroundColor = widget.backgroundColor;
+    _emoji = widget.emoji;
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Státusz jegyzet'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(
+              context,
+              NoteEditorResult(
+                text: null,
+                textColor: _textColor,
+                backgroundColor: _backgroundColor,
+                emoji: _emoji,
+                deleted: true,
+              ),
+            ),
+            child: const Text('Törlés'),
+          ),
+          const SizedBox(width: 8),
+          FilledButton(
+            onPressed: () => Navigator.pop(
+              context,
+              NoteEditorResult(
+                text: _controller.text,
+                textColor: _textColor,
+                backgroundColor: _backgroundColor,
+                emoji: _emoji,
+              ),
+            ),
+            child: const Text('Mentés'),
+          ),
+          const SizedBox(width: 12),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: _controller,
+              maxLength: 120,
+              maxLines: 4,
+              decoration: const InputDecoration(
+                labelText: 'Mit mondjunk?',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 20),
+            Text('Színek', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: _colorButton(
+                    context: context,
+                    color: _textColor,
+                    label: 'Szöveg',
+                    onTap: () => _pickColor(true),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: _colorButton(
+                    context: context,
+                    color: _backgroundColor,
+                    label: 'Háttér',
+                    onTap: () => _pickColor(false),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            FilledButton.tonalIcon(
+              onPressed: () async {
+                final emoji = await NoteEditorPage.pickEmoji(context, selected: _emoji);
+                if (!mounted) return;
+                setState(() => _emoji = emoji);
+              },
+              icon: const Icon(Icons.emoji_emotions_outlined),
+              label: Text(_emoji?.isNotEmpty == true ? 'Emoji: $_emoji' : 'Emoji választása'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _colorButton({required BuildContext context, required Color color, required String label, required VoidCallback onTap}) {
+    return OutlinedButton(
+      onPressed: onTap,
+      style: OutlinedButton.styleFrom(padding: const EdgeInsets.symmetric(vertical: 14)),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(width: 22, height: 22, decoration: BoxDecoration(color: color, shape: BoxShape.circle, border: Border.all(color: Colors.white24))),
+          const SizedBox(width: 10),
+          Text(label),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _pickColor(bool text) async {
+    final color = await showDialog<Color?>(
+      context: context,
+      builder: (context) => _ColorPickerDialog(initial: text ? _textColor : _backgroundColor),
+    );
+    if (color == null) return;
+    setState(() {
+      if (text) {
+        _textColor = color;
+      } else {
+        _backgroundColor = color;
+      }
+    });
+  }
+}
+
+class _ColorPickerDialog extends StatefulWidget {
+  const _ColorPickerDialog({required this.initial});
+  final Color initial;
+
+  @override
+  State<_ColorPickerDialog> createState() => _ColorPickerDialogState();
+}
+
+class _ColorPickerDialogState extends State<_ColorPickerDialog> {
+  late HSVColor _hsv;
+
+  @override
+  void initState() {
+    super.initState();
+    _hsv = HSVColor.fromColor(widget.initial);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Szín választása'),
+      content: SizedBox(
+        width: 260,
+        height: 220,
+        child: Column(
+          children: [
+            Expanded(
+              child: ColorPickerSlider(
+                value: _hsv,
+                onChanged: (value) => setState(() => _hsv = value),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text('HEX: #${_hsv.toColor().value.toRadixString(16).padLeft(8, '0').substring(2).toUpperCase()}'),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(onPressed: () => Navigator.pop(context), child: const Text('Mégse')),
+        FilledButton(onPressed: () => Navigator.pop(context, _hsv.toColor()), child: const Text('OK')),
+      ],
+    );
+  }
+}
+
+class ColorPickerSlider extends StatelessWidget {
+  const ColorPickerSlider({super.key, required this.value, required this.onChanged});
+
+  final HSVColor value;
+  final ValueChanged<HSVColor> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Expanded(
+          child: ShaderMask(
+            shaderCallback: (rect) => const LinearGradient(colors: [Colors.red, Colors.yellow, Colors.green, Colors.cyan, Colors.blue, Colors.purple, Colors.red]).createShader(rect),
+            child: Slider(
+              value: value.hue,
+              min: 0,
+              max: 360,
+              onChanged: (hue) => onChanged(value.withHue(hue)),
+            ),
+          ),
+        ),
+        Slider(
+          value: value.saturation,
+          onChanged: (s) => onChanged(value.withSaturation(s)),
+        ),
+        Slider(
+          value: value.value,
+          onChanged: (v) => onChanged(value.withValue(v)),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/felulet/profil/widgets/note_overlay.dart
+++ b/lib/felulet/profil/widgets/note_overlay.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+class NoteOverlay extends StatelessWidget {
+  const NoteOverlay({
+    super.key,
+    required this.text,
+    required this.textColor,
+    required this.bgColor,
+    this.emoji,
+    required this.onEdit,
+    required this.onPickEmoji,
+    this.maxWidth = 220,
+  });
+
+  final String text;
+  final Color textColor;
+  final Color bgColor;
+  final String? emoji;
+  final VoidCallback onEdit;
+  final VoidCallback onPickEmoji;
+  final double maxWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxWidth: maxWidth),
+      child: GestureDetector(
+        onTap: onEdit,
+        child: Container(
+          decoration: BoxDecoration(
+            color: bgColor,
+            borderRadius: BorderRadius.circular(18),
+            border: Border.all(color: Colors.white.withOpacity(0.1)),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (emoji != null && emoji!.isNotEmpty)
+                    Text(emoji!, style: const TextStyle(fontSize: 20)),
+                  if (emoji != null && emoji!.isNotEmpty) const SizedBox(width: 6),
+                  Expanded(
+                    child: Text(
+                      text,
+                      style: TextStyle(color: textColor, fontWeight: FontWeight.w600),
+                      maxLines: 3,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.edit, size: 18),
+                    color: textColor,
+                    onPressed: onEdit,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 6),
+              TextButton.icon(
+                onPressed: onPickEmoji,
+                icon: const Icon(Icons.emoji_emotions_outlined, size: 16),
+                label: const Text('Emoji'),
+                style: TextButton.styleFrom(foregroundColor: textColor),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/felulet/profil/widgets/profile_banner_card.dart
+++ b/lib/felulet/profil/widgets/profile_banner_card.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+
+class ProfileBannerCard extends StatelessWidget {
+  const ProfileBannerCard({
+    super.key,
+    required this.image,
+    required this.onPick,
+    required this.onDelete,
+  });
+
+  final ImageProvider? image;
+  final Future<void> Function(ImageSource source) onPick;
+  final Future<void> Function() onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(0.04),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: Colors.white.withOpacity(0.05)),
+        boxShadow: [
+          BoxShadow(color: Colors.black.withOpacity(0.22), blurRadius: 24, offset: const Offset(0, 12)),
+        ],
+      ),
+      padding: const EdgeInsets.all(14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.wallpaper, size: 18),
+              const SizedBox(width: 8),
+              Text(
+                'Banner',
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+              ),
+              const Spacer(),
+              IconButton(
+                icon: const Icon(Icons.more_horiz),
+                onPressed: () => _showOptions(context),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          AspectRatio(
+            aspectRatio: 3 / 1,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(14),
+              child: DecoratedBox(
+                decoration: BoxDecoration(color: Colors.white.withOpacity(0.04)),
+                child: image != null
+                    ? Image(image: image!, fit: BoxFit.cover)
+                    : Center(
+                        child: Text(
+                          'Adj hozzá egy borítóképet',
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showOptions(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (context) => SafeArea(
+        child: Wrap(
+          children: [
+            ListTile(
+              leading: const Icon(Icons.photo_library),
+              title: const Text('Galériából'),
+              onTap: () {
+                Navigator.pop(context);
+                onPick(ImageSource.gallery);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.camera_alt),
+              title: const Text('Fénykép készítése'),
+              onTap: () {
+                Navigator.pop(context);
+                onPick(ImageSource.camera);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.delete_outline),
+              title: const Text('Banner törlése'),
+              onTap: () {
+                Navigator.pop(context);
+                onDelete();
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/felulet/profil/widgets/profile_quick_actions.dart
+++ b/lib/felulet/profil/widgets/profile_quick_actions.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+class ProfileQuickActions extends StatelessWidget {
+  const ProfileQuickActions({
+    super.key,
+    required this.onFramePicker,
+    required this.onRandomize,
+    required this.onEditStatus,
+  });
+
+  final VoidCallback onFramePicker;
+  final VoidCallback onRandomize;
+  final VoidCallback onEditStatus;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 12,
+      runSpacing: 12,
+      alignment: WrapAlignment.center,
+      children: [
+        _QuickActionButton(
+          icon: Icons.palette_outlined,
+          label: 'Keretek',
+          onTap: onFramePicker,
+        ),
+        _QuickActionButton(
+          icon: Icons.casino_outlined,
+          label: 'Random',
+          onTap: onRandomize,
+        ),
+        _QuickActionButton(
+          icon: Icons.edit_note_outlined,
+          label: 'Státusz',
+          onTap: onEditStatus,
+        ),
+      ],
+    );
+  }
+}
+
+class _QuickActionButton extends StatelessWidget {
+  const _QuickActionButton({required this.icon, required this.label, required this.onTap});
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      color: Colors.white.withOpacity(0.04),
+      borderRadius: BorderRadius.circular(16),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(16),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, color: theme.colorScheme.primary),
+              const SizedBox(width: 8),
+              Text(label, style: theme.textTheme.titleSmall),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/felulet/profil/widgets/profile_save_bar.dart
+++ b/lib/felulet/profil/widgets/profile_save_bar.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+class ProfileSaveBar extends StatelessWidget {
+  const ProfileSaveBar({
+    super.key,
+    required this.visible,
+    required this.saving,
+    required this.onDiscard,
+    required this.onSave,
+  });
+
+  final bool visible;
+  final bool saving;
+  final VoidCallback onDiscard;
+  final VoidCallback onSave;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: AnimatedSlide(
+        duration: const Duration(milliseconds: 240),
+        offset: visible ? Offset.zero : const Offset(0, 1),
+        child: AnimatedOpacity(
+          duration: const Duration(milliseconds: 240),
+          opacity: visible ? 1 : 0,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+            child: Material(
+              elevation: 10,
+              borderRadius: BorderRadius.circular(20),
+              color: Theme.of(context).colorScheme.surface,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                child: Row(
+                  children: [
+                    const Icon(Icons.info_outline, size: 20),
+                    const SizedBox(width: 12),
+                    const Expanded(child: Text('Vannak mentetlen módosítások.')),
+                    TextButton(onPressed: onDiscard, child: const Text('Visszaállítás')),
+                    const SizedBox(width: 8),
+                    FilledButton.icon(
+                      onPressed: saving ? null : onSave,
+                      icon: saving
+                          ? const SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2))
+                          : const Icon(Icons.save),
+                      label: Text(saving ? 'Mentés...' : 'Mentés'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/felulet/profil/widgets/social_buttons.dart
+++ b/lib/felulet/profil/widgets/social_buttons.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+class SocialButtonsRow extends StatelessWidget {
+  const SocialButtonsRow({
+    super.key,
+    required this.facebook,
+    required this.instagram,
+    required this.tiktok,
+    required this.youtube,
+    required this.onEdit,
+    required this.onOpen,
+  });
+
+  final String? facebook;
+  final String? instagram;
+  final String? tiktok;
+  final String? youtube;
+  final Future<void> Function(String title, String prefKey, String? current) onEdit;
+  final Future<void> Function(String? url) onOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 22,
+      runSpacing: 14,
+      alignment: WrapAlignment.center,
+      children: [
+        _SocialButton(
+          icon: FontAwesomeIcons.facebookF,
+          color: const Color(0xFF1877F2),
+          title: 'Facebook',
+          link: facebook,
+          prefKey: 'profile_facebook',
+          onEdit: onEdit,
+          onOpen: onOpen,
+        ),
+        _SocialButton(
+          icon: FontAwesomeIcons.instagram,
+          gradient: const LinearGradient(
+            colors: [Color(0xFFF58529), Color(0xFFDD2A7B), Color(0xFF8134AF), Color(0xFF515BD4)],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+          title: 'Instagram',
+          link: instagram,
+          prefKey: 'profile_instagram',
+          onEdit: onEdit,
+          onOpen: onOpen,
+        ),
+        _SocialButton(
+          icon: FontAwesomeIcons.tiktok,
+          color: Colors.black,
+          title: 'TikTok',
+          link: tiktok,
+          prefKey: 'profile_tiktok',
+          onEdit: onEdit,
+          onOpen: onOpen,
+        ),
+        _SocialButton(
+          icon: FontAwesomeIcons.youtube,
+          color: const Color(0xFFFF0000),
+          title: 'YouTube',
+          link: youtube,
+          prefKey: 'profile_youtube',
+          onEdit: onEdit,
+          onOpen: onOpen,
+        ),
+      ],
+    );
+  }
+}
+
+class _SocialButton extends StatelessWidget {
+  const _SocialButton({
+    required this.icon,
+    required this.title,
+    required this.prefKey,
+    required this.onEdit,
+    required this.onOpen,
+    this.link,
+    this.color,
+    this.gradient,
+  });
+
+  final IconData icon;
+  final String title;
+  final String prefKey;
+  final String? link;
+  final Color? color;
+  final LinearGradient? gradient;
+  final Future<void> Function(String title, String prefKey, String? current) onEdit;
+  final Future<void> Function(String? url) onOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    final enabled = link != null && link!.isNotEmpty;
+    final decoration = gradient != null
+        ? BoxDecoration(
+            gradient: gradient,
+            shape: BoxShape.circle,
+            boxShadow: enabled ? [const BoxShadow(color: Color(0x44000000), blurRadius: 12, offset: Offset(0, 4))] : [],
+          )
+        : BoxDecoration(
+            color: enabled ? color ?? Theme.of(context).colorScheme.primary : Colors.grey.shade700,
+            shape: BoxShape.circle,
+            boxShadow: enabled && color != null
+                ? [BoxShadow(color: color!.withOpacity(0.4), blurRadius: 16, offset: const Offset(0, 6))]
+                : [],
+          );
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        GestureDetector(
+          onTap: enabled ? () => onOpen(link) : null,
+          onLongPress: enabled
+              ? () async {
+                  await Clipboard.setData(ClipboardData(text: link));
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('$title link másolva.')),
+                  );
+                }
+              : null,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 220),
+            width: 60,
+            height: 60,
+            decoration: decoration,
+            alignment: Alignment.center,
+            child: FaIcon(icon, color: Colors.white, size: 26),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              icon: const Icon(Icons.edit, size: 18),
+              tooltip: '$title szerkesztése',
+              onPressed: () => onEdit(title, prefKey, link),
+            ),
+            IconButton(
+              icon: const Icon(Icons.open_in_new, size: 18),
+              tooltip: '$title megnyitása',
+              onPressed: enabled ? () => onOpen(link) : null,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'felulet/bejel.dart';
+import 'felulet/menu.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final seed = const Color(0xFF00C853);
+    return MaterialApp(
+      title: 'Proiect Flutter',
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: seed, brightness: Brightness.dark),
+        useMaterial3: true,
+        brightness: Brightness.dark,
+      ),
+      initialRoute: '/login',
+      routes: {
+        '/login': (_) => const BejelentkezesPage(),
+        '/menu': (_) => const MenuScreen(),
+      },
+    );
+  }
+}

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,0 +1,144 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class ApiException implements Exception {
+  final String message;
+  final int? status;
+  ApiException(this.message, {this.status});
+  @override
+  String toString() => 'ApiException(${status ?? ''}): $message';
+}
+
+class ApiService {
+  // IMPORTANT: On Android emulator use 10.0.2.2 instead of localhost.
+  // On a real device, use your PC's LAN IP where PHP is running.
+  static const String baseUrl = 'http://127.0.0.1:8088';
+
+  Uri _url(String path) => Uri.parse('$baseUrl$path');
+
+  Future<(String token, Map<String, dynamic> user)> login({required String username, required String password}) async {
+    final res = await http.post(
+      _url('/api/login.php'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'username': username, 'password': password}),
+    );
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['token'] != null) {
+      return (data['token'] as String, Map<String, dynamic>.from(data['user'] as Map));
+    }
+    throw ApiException(data['error']?.toString() ?? 'Login failed', status: res.statusCode);
+  }
+
+  Future<Map<String, dynamic>> getProfile(String token) async {
+    final res = await http.get(
+      _url('/api/profile.php'),
+      headers: {'Authorization': 'Bearer $token'},
+    );
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['profile'] != null) {
+      return Map<String, dynamic>.from(data['profile'] as Map);
+    }
+    throw ApiException(data['error']?.toString() ?? 'Cannot load profile', status: res.statusCode);
+  }
+
+  Future<Map<String, dynamic>> updateProfile(String token, Map<String, dynamic> payload) async {
+    final res = await http.post(
+      _url('/api/profile.php'),
+      headers: {'Authorization': 'Bearer $token', 'Content-Type': 'application/json'},
+      body: jsonEncode(payload),
+    );
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['profile'] != null) {
+      return Map<String, dynamic>.from(data['profile'] as Map);
+    }
+    throw ApiException(data['error']?.toString() ?? 'Cannot update profile', status: res.statusCode);
+  }
+
+  Map<String, dynamic> _decode(http.Response res) {
+    try {
+      final body = jsonDecode(res.body);
+      return (body is Map<String, dynamic>) ? body : <String, dynamic>{'data': body};
+    } catch (_) {
+      return <String, dynamic>{'error': 'Invalid JSON', 'raw': res.body};
+    }
+  }
+
+  Future<String> uploadAvatarBytes(String token, List<int> bytes, {String filename = 'avatar.jpg', String contentType = 'image/jpeg'}) async {
+    final req = http.MultipartRequest('POST', _url('/api/avatar.php'))
+      ..headers['Authorization'] = 'Bearer $token'
+      ..files.add(http.MultipartFile.fromBytes('file', bytes, filename: filename, contentType: _mediaType(contentType)));
+    final res = await http.Response.fromStream(await req.send());
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['avatar_url'] != null) {
+      return data['avatar_url'] as String;
+    }
+    throw ApiException(data['error']?.toString() ?? 'Upload failed', status: res.statusCode);
+  }
+
+  Future<String> uploadAvatarPath(String token, String path, {String? filename, String? contentType}) async {
+    final req = http.MultipartRequest('POST', _url('/api/avatar.php'))
+      ..headers['Authorization'] = 'Bearer $token'
+      ..files.add(await http.MultipartFile.fromPath('file', path, filename: filename, contentType: _mediaType(contentType)));
+    final res = await http.Response.fromStream(await req.send());
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['avatar_url'] != null) {
+      return data['avatar_url'] as String;
+    }
+    throw ApiException(data['error']?.toString() ?? 'Upload failed', status: res.statusCode);
+  }
+
+  Future<void> deleteAvatar(String token) async {
+    final res = await http.delete(_url('/api/avatar.php'), headers: {'Authorization': 'Bearer $token'});
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      final data = _decode(res);
+      throw ApiException(data['error']?.toString() ?? 'Delete failed', status: res.statusCode);
+    }
+  }
+
+  Future<String> uploadBannerBytes(String token, List<int> bytes, {String filename = 'banner.jpg', String contentType = 'image/jpeg'}) async {
+    final req = http.MultipartRequest('POST', _url('/api/banner.php'))
+      ..headers['Authorization'] = 'Bearer $token'
+      ..files.add(http.MultipartFile.fromBytes('file', bytes, filename: filename, contentType: _mediaType(contentType)));
+    final res = await http.Response.fromStream(await req.send());
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['banner_url'] != null) {
+      return data['banner_url'] as String;
+    }
+    throw ApiException(data['error']?.toString() ?? 'Upload failed', status: res.statusCode);
+  }
+
+  Future<String> uploadBannerPath(String token, String path, {String? filename, String? contentType}) async {
+    final req = http.MultipartRequest('POST', _url('/api/banner.php'))
+      ..headers['Authorization'] = 'Bearer $token'
+      ..files.add(await http.MultipartFile.fromPath('file', path, filename: filename, contentType: _mediaType(contentType)));
+    final res = await http.Response.fromStream(await req.send());
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['banner_url'] != null) {
+      return data['banner_url'] as String;
+    }
+    throw ApiException(data['error']?.toString() ?? 'Upload failed', status: res.statusCode);
+  }
+
+  Future<void> deleteBanner(String token) async {
+    final res = await http.delete(_url('/api/banner.php'), headers: {'Authorization': 'Bearer $token'});
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      final data = _decode(res);
+      throw ApiException(data['error']?.toString() ?? 'Delete failed', status: res.statusCode);
+    }
+  }
+
+  // Helper to build MediaType without importing http_parser directly
+  dynamic _mediaType(String? contentType) {
+    if (contentType == null) return null;
+    try {
+      final parts = contentType.split('/');
+      if (parts.length == 2) {
+        // http.MultipartFile expects a MediaType from package:http_parser, but
+        // it accepts a dynamic. Avoid hard dep; null is also acceptable.
+        // However, when null, http will infer from filename. We'll return null if parsing fails.
+        // Leaving as null keeps compatibility.
+      }
+    } catch (_) {}
+    return null;
+  }
+}

--- a/lib/services/sticker_service.dart
+++ b/lib/services/sticker_service.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show rootBundle;
+
+class Sticker {
+  const Sticker({this.asset, this.url});
+
+  final String? asset;
+  final String? url;
+}
+
+class StickerService {
+  Future<List<Sticker>> loadStickers() async {
+    try {
+      final manifestContent = await rootBundle.loadString('AssetManifest.json');
+      final Map<String, dynamic> manifestMap = jsonDecode(manifestContent) as Map<String, dynamic>;
+      final entries = manifestMap.keys
+          .where((key) => key.startsWith('assets/stickers/') &&
+              (key.endsWith('.png') || key.endsWith('.webp') || key.endsWith('.svg')))
+          .toList()
+        ..sort();
+      return entries.map((path) => Sticker(asset: path.split('assets/stickers/').last)).toList();
+    } catch (_) {
+      return const [];
+    }
+  }
+}

--- a/lib/utils/i18n.dart
+++ b/lib/utils/i18n.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/widgets.dart';
+
+class I18n {
+  static const Map<String, String> _defaults = {
+    'profile': 'Profil',
+    'name': 'Név',
+    'description': 'Leírás',
+    'avatar_frame': 'Avatar keret',
+    'social_media': 'Social media',
+    'sticker': 'Matrica',
+    'remove': 'Eltávolítás',
+    'not_authenticated': 'Nem vagy bejelentkezve.',
+    'profile_saved': 'Profil mentve.',
+    'save_failed': 'Mentés sikertelen',
+    'upload_error': 'Feltöltési hiba',
+    'avatar_updated': 'Avatar frissítve.',
+    'banner_updated': 'Banner frissítve.',
+    'avatar_delete_failed': 'Avatar törlése nem sikerült',
+    'banner_delete_failed': 'Banner törlése nem sikerült',
+    'image_load_error': 'Nem sikerült betölteni a képet',
+    'edit': 'Szerkesztés',
+    'link_hint': 'Link vagy @felhasználónév',
+    'cancel': 'Mégse',
+    'save': 'Mentés',
+    'missing_link': 'Nincs beállított link.',
+    'invalid_url': 'Érvénytelen URL.',
+    'cannot_launch': 'Nem sikerült megnyitni a linket.',
+    'pick_from_gallery': 'Galériából',
+    'take_photo': 'Fénykép készítése',
+    'delete_avatar': 'Avatar törlése',
+    'no_stickers': 'Nincsenek matricák az assets/stickers mappában.',
+    'frame_picker': 'Keretválasztó',
+    'search_frames': 'Keresés...',
+    'unsaved_changes': 'Mentetlen módosítások',
+    'leave_without_save': 'Elhagyod az oldalt mentés nélkül?',
+    'stay': 'Maradok',
+    'leave': 'Kilépés',
+  };
+
+  static String t(BuildContext context, String key) {
+    return _defaults[key] ?? key;
+  }
+}

--- a/lib/utils/ui_utils.dart
+++ b/lib/utils/ui_utils.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class UiUtils {
+  static String normalizeUploadUrl(String url) {
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      return url;
+    }
+    return 'https://$url';
+  }
+
+  static String normalizeSocial(String prefKey, String input) {
+    final value = input.trim();
+    if (value.isEmpty) return '';
+    final isUrl = value.startsWith('http://') || value.startsWith('https://');
+    String username = value.startsWith('@') ? value.substring(1) : value;
+    if (isUrl) return value;
+    switch (prefKey) {
+      case 'profile_facebook':
+        return 'https://facebook.com/$username';
+      case 'profile_instagram':
+        return 'https://instagram.com/$username';
+      case 'profile_tiktok':
+        if (username.contains('/')) return 'https://tiktok.com/$username';
+        return 'https://www.tiktok.com/@$username';
+      case 'profile_youtube':
+        if (username.startsWith('@')) return 'https://youtube.com/$username';
+        if (username.startsWith('UC')) return 'https://youtube.com/channel/$username';
+        return 'https://youtube.com/@$username';
+      default:
+        return value;
+    }
+  }
+}
+
+extension ThemeDataX on ThemeData {
+  Color overlayColor(double opacity) => colorScheme.surface.withOpacity(opacity);
+}


### PR DESCRIPTION
## Summary
- overhaul the profile experience with a modular 2025-style layout, auto-save bar, banner editor, halo controls, and richer avatar tooling
- split the implementation into focused widgets (avatar header, banner card, quick actions, completion meter, save bar, etc.) for maintainability
- restructure the navigation menu into reusable components and update API/util layers for banners, stickers, and translation helpers

## Testing
- no automated tests were run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68da533e56548322a2bfd55439ac4569